### PR TITLE
fix(deps): allow ovos-bus-client 2.x (widen cap to <3.0.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ovos-plugin-manager>=2.1.0,<3.0.0
 ovos-utils>=0.0.32,<2.0.0
-ovos-bus-client>=0.0.3,<2.0.0
+ovos-bus-client>=0.0.3,<3.0.0


### PR DESCRIPTION
ovos-bus-client 2.x dropped only the bundled hivemind protocol + messagebus solver (#207) — no API break (#215). Widen `<2.0.0`→`<3.0.0` (1.x stays default). Stack-wide migration for HiveMind 2.x adoption.